### PR TITLE
Fix a bug when the device of manolayer is cpu and use_pca=False

### DIFF
--- a/manopth/rotproj.py
+++ b/manopth/rotproj.py
@@ -8,14 +8,15 @@ def batch_rotprojs(batches_rotmats):
         for rot_idx, rotmat in enumerate(batch_rotmats):
             # GPU implementation of svd is VERY slow
             # ~ 2 10^-3 per hit vs 5 10^-5 on cpu
-            U, S, V = rotmat.cpu().svd()
-            rotmat = torch.matmul(U, V.transpose(0, 1))
+            _device = rotmat.device
+            U, S, V_T = torch.linalg.svd(rotmat.cpu())
+            rotmat = torch.matmul(U, V_T)
             orth_det = rotmat.det()
             # Remove reflection
             if orth_det < 0:
                 rotmat[:, 2] = -1 * rotmat[:, 2]
 
-            rotmat = rotmat.cuda()
+            rotmat = rotmat.to(_device)
             proj_batch_rotmats.append(rotmat)
         proj_rotmats.append(torch.stack(proj_batch_rotmats))
     return torch.stack(proj_rotmats)


### PR DESCRIPTION
When `use_pca=False`, if the device of MANO layer is CPU, it will raise error on this [line](https://github.com/hassony2/manopth/blob/master/manopth/manolayer.py#L187). This error is due to `self.th_posedirs` is on cpu device but `th_pose_map` is on cuda device.

The reason lies in [the output value](https://github.com/hassony2/manopth/blob/master/manopth/manolayer.py#L165) of **batch_rotprojs**, `th_pose_map`, is always on GPU. Because [inside this function](https://github.com/hassony2/manopth/blob/master/manopth/rotproj.py#L18), it always converts the output to GPU. After this PR, the output value will remain on its original device after **batch_rotprojs**.

In addition,  the [torch.svd()](https://pytorch.org/docs/stable/generated/torch.svd.html#torch.svd) is deprecated in favor of [torch.linalg.svd()](https://pytorch.org/docs/stable/generated/torch.linalg.svd.html#torch.linalg.svd), which follows the same convention as `np.linalg.svd` to output `(U, S, V_T)`.