### PR TITLE
Fix wrong index finger fingertip position

### DIFF
--- a/manopth/manolayer.py
+++ b/manopth/manolayer.py
@@ -248,9 +248,9 @@ class ManoLayer(Module):
         # In addition to MANO reference joints we sample vertices on each finger
         # to serve as finger tips
         if self.side == 'right':
-            tips = th_verts[:, [745, 317, 444, 556, 673]]
+            tips = th_verts[:, [745, 319, 444, 556, 673]]
         else:
-            tips = th_verts[:, [745, 317, 445, 556, 673]]
+            tips = th_verts[:, [745, 319, 445, 556, 673]]
         if bool(root_palm):
             palm = (th_verts[:, 95] + th_verts[:, 22]).unsqueeze(1) / 2
             th_jtr = torch.cat([palm, th_jtr[:, 1:]], 1)


### PR DESCRIPTION
I noticed that the fingertip position for the index finger is a bit too much left on the finger (can already be seen in the [picture on the GitHub](https://github.com/hassony2/manopth/blob/master/assets/mano_layer.png) ). The vertex index to choose for this fingertip position should be changed.

Min-demo plot before change:
![2023-04-21_manopth_index_fingertip_fix_before](https://user-images.githubusercontent.com/82732496/233603758-2403873e-bf8b-41f4-a64d-fa0065f6daf6.png)

Min-demo plot after change:
![2023-04-21_manopth_index_fingertip_fix_after](https://user-images.githubusercontent.com/82732496/233603830-3126c046-b69b-46a9-bbb8-182b7a30218c.png)

